### PR TITLE
Refatorar função str_to_bool para tratamento robusto de entradas

### DIFF
--- a/curso-1/test_exercise.py
+++ b/curso-1/test_exercise.py
@@ -1,33 +1,54 @@
 import unittest
 
-
 def str_to_bool(value):
-    try:
-         value = value.lower()
-    except AttributeError:
-        raise AttributeError(f"{value} must be of type string")
-    true_values = ['y','yes']
-    false_values = ['no', 'n']
+    """
+    Converte uma string em um valor booleano.
+    Aceita algumas variações de 'sim' e 'não' como entrada.
+    
+    Parâmetros:
+        value (str): A string a ser convertida.
+
+    Retorna:
+        bool: True ou False conforme o valor fornecido.
+
+    Levanta:
+        TypeError: Se o valor não for uma string.
+        ValueError: Se o valor não puder ser interpretado como booleano.
+    """
+    if not isinstance(value, str):
+        raise TypeError(f"'{value}' must be of type 'str'")
+
+    value = value.strip().lower()
+    true_values = {'y', 'yes', 'true', '1'}
+    false_values = {'n', 'no', 'false', '0'}
 
     if value in true_values:
         return True
-    if value in false_values:
+    elif value in false_values:
         return False
+    else:
+        raise ValueError(f"'{value}' is not a valid boolean string")
 
 class TestStrToBool(unittest.TestCase):
+    """Testa a função str_to_bool."""
 
-    def test_y_is_true(self):
-        result = str_to_bool('y')
-        self.assertTrue(result)
+    def test_true_values(self):
+        for val in ['y', 'Y', 'yes', 'Yes', 'TRUE', '1']:
+            with self.subTest(val=val):
+                self.assertTrue(str_to_bool(val))
 
-    def test_yes_is_true(self):
-        result = str_to_bool('Yes')
-        self.assertTrue(result)
+    def test_false_values(self):
+        for val in ['n', 'N', 'no', 'No', 'FALSE', '0']:
+            with self.subTest(val=val):
+                self.assertFalse(str_to_bool(val))
 
-    def test_invalid_value(self):
-        with self.assertRaises(AttributeError):
+    def test_invalid_type(self):
+        with self.assertRaises(TypeError):
             str_to_bool(1)
+
+    def test_unexpected_value(self):
+        with self.assertRaises(ValueError):
+            str_to_bool('maybe')
 
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
Ajusta a função str_to_bool para aceitar variações de entradas booleanas e lança exceções para tipos inválidos. Inclui testes unitários para verificar comportamentos esperados.